### PR TITLE
Bump minimum versions of sunpy and python

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ variables:
   CI_NAME: Azure Pipelines
   CI_BUILD_ID: $(Build.BuildId)
   CI_BUILD_URL: "https://dev.azure.com/https://github.com/i4Ds/STIXCore.git/_build/results?buildId=$(Build.BuildId)"
-  CIBW_BUILD: cp36-* cp37-* cp38-*
+  CIBW_BUILD: cp37-* cp38-* cp39-*
   CIBW_SKIP: "*-win32 *-manylinux1_i686"
 
 resources:
@@ -34,14 +34,14 @@ jobs:
     submodules: true
     coverage: codecov
     envs:
-      - macos: py36
-        name: py36_mac
+      - macos: py37
+        name: py37_mac
 
-      - windows: py36
-        name: py36_win
+      - windows: py37
+        name: py37_win
 
-      - linux: py36
-        name: py36_linux
+      - linux: py37
+        name: py37_linux
 
       - linux: codestyle
         name: codestyle

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,10 @@ long_description = file: README.rst
 include_package_data = True
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
-    sunpy
+    sunpy>=3.0.1
     spiceypy
     bitstring
     roentgen

--- a/stixcore/soop/manager.py
+++ b/stixcore/soop/manager.py
@@ -368,7 +368,7 @@ class SOOPManager():
         Based on all found entries for the filter parameters a list of
         HeaderKeyword is generated combining all avaliable information.
 
-       Parameters
+        Parameters
         ----------
         start : `datetime`
             start time to look for overlapping observations and SOOPs in utc time
@@ -376,10 +376,11 @@ class SOOPManager():
             end time to look for overlapping observations and SOOPs in utc time, by default None ()
         otype : `SoopObservationType`, optional
             filter for specific type of observations, by default SoopObservationType.ALL
+
         Returns
         -------
         `list`
-            a list of `HeaderKeyword`
+            A list of `HeaderKeyword`
 
         Raises
         ------

--- a/stixcore/time/datetime.py
+++ b/stixcore/time/datetime.py
@@ -27,6 +27,7 @@ MAX_FINE = 2**16 - 1
 class TimeInfo(MixinInfo):
     attr_names = MixinInfo.attr_names
     _supports_indexing = True
+    _represent_as_dict_attrs = ('coarse', 'fine')
 
     def get_sortable_arrays(self):
         pass

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}
+    py{37,38,39}
     build_docs
     codestyle
 isolated_build = true


### PR DESCRIPTION
Min version of python now 3.7 and min version of sunpy 3.0.1