### PR TITLE
add unique get name function

### DIFF
--- a/stixcore/idb/idb.py
+++ b/stixcore/idb/idb.py
@@ -263,7 +263,7 @@ class IDBParameter(IDBPacketTypeInfo):
         self.S2K_TYPE = S2K_TYPE
         self.bin_format = bin_format
 
-    def get_product_attribut_name(self):
+    def get_product_attribute_name(self):
         return self.PCF_DESCR.lower().replace(' ', '_').replace('_-_', '-')
 
 

--- a/stixcore/idb/idb.py
+++ b/stixcore/idb/idb.py
@@ -263,6 +263,9 @@ class IDBParameter(IDBPacketTypeInfo):
         self.S2K_TYPE = S2K_TYPE
         self.bin_format = bin_format
 
+    def get_product_attribut_name(self):
+        return self.PCF_DESCR.lower().replace(' ', '_').replace('_-_', '-')
+
 
 class IDBStaticParameter(IDBParameter):
     """A class to represent a parameter of a static SCOS-2000 Telemetry Packet.

--- a/stixcore/products/level0/housekeepingL0.py
+++ b/stixcore/products/level0/housekeepingL0.py
@@ -102,7 +102,7 @@ class MiniReport(HKProduct):
             if nix.startswith("NIXG") or nix == 'NIX00020':
                 continue
 
-            name = param.idb_info.get_product_attribut_name()
+            name = param.idb_info.get_product_attribute_name()
             data.add_basic(name=name, nix=nix, attr='value', packets=packets)
 
         data['control_index'] = range(len(control))

--- a/stixcore/products/level0/housekeepingL0.py
+++ b/stixcore/products/level0/housekeepingL0.py
@@ -150,7 +150,7 @@ class MaxiReport(HKProduct):
             if nix.startswith("NIXG") or nix == 'NIX00020':
                 continue
 
-            name = param.idb_info.get_product_attribut_name()
+            name = param.idb_info.get_product_attribute_name()
             data.add_basic(name=name, nix=nix, attr='value', packets=packets)
 
         data['control_index'] = range(len(control))

--- a/stixcore/products/level0/housekeepingL0.py
+++ b/stixcore/products/level0/housekeepingL0.py
@@ -102,7 +102,7 @@ class MiniReport(HKProduct):
             if nix.startswith("NIXG") or nix == 'NIX00020':
                 continue
 
-            name = param.idb_info.PCF_DESCR.lower().replace(' ', '_')
+            name = param.idb_info.get_product_attribut_name()
             data.add_basic(name=name, nix=nix, attr='value', packets=packets)
 
         data['control_index'] = range(len(control))
@@ -150,7 +150,7 @@ class MaxiReport(HKProduct):
             if nix.startswith("NIXG") or nix == 'NIX00020':
                 continue
 
-            name = param.idb_info.PCF_DESCR.lower().replace(' ', '_')
+            name = param.idb_info.get_product_attribut_name()
             data.add_basic(name=name, nix=nix, attr='value', packets=packets)
 
         data['control_index'] = range(len(control))

--- a/stixcore/products/product.py
+++ b/stixcore/products/product.py
@@ -561,7 +561,7 @@ class DefaultProduct(GenericProduct, L1Mixin):
             reshape = True
         for nix, param in packets.data[0].__dict__.items():
 
-            name = param.idb_info.PCF_DESCR.upper().replace(' ', '_')
+            name = param.idb_info.get_product_attribut_name()
             data.add_basic(name=name, nix=nix, attr='value', packets=packets, reshape=reshape)
 
         data['control_index'] = range(len(control))

--- a/stixcore/products/product.py
+++ b/stixcore/products/product.py
@@ -561,7 +561,7 @@ class DefaultProduct(GenericProduct, L1Mixin):
             reshape = True
         for nix, param in packets.data[0].__dict__.items():
 
-            name = param.idb_info.get_product_attribut_name()
+            name = param.idb_info.get_product_attribute_name()
             data.add_basic(name=name, nix=nix, attr='value', packets=packets, reshape=reshape)
 
         data['control_index'] = range(len(control))


### PR DESCRIPTION
in housekeepung and defaultproduct diferent naming schematas where used.
also this will fix names like: `lv_-_enabled_status` to `lv-enabled_status`