### PR TITLE
shring the end2end test files the a minimum

### DIFF
--- a/stixcore/util/scripts/end2end_testing.py
+++ b/stixcore/util/scripts/end2end_testing.py
@@ -3,6 +3,7 @@ import sys
 import shutil
 from pathlib import Path
 from xml.etree import ElementTree as Et
+from collections import defaultdict
 
 from stixcore.config.config import CONFIG
 from stixcore.data.test import test_data
@@ -11,6 +12,7 @@ from stixcore.io.soc.manager import SOCManager
 from stixcore.processing.L0toL1 import Level1
 from stixcore.processing.LBtoL0 import Level0
 from stixcore.processing.TMTCtoLB import process_tmtc_to_levelbinary
+from stixcore.products.level0.scienceL0 import ScienceProduct
 from stixcore.products.product import Product
 from stixcore.soop.manager import SOOPManager
 from stixcore.tmtc.packets import TMTC
@@ -26,12 +28,12 @@ import pytest  # noqa
 END_TO_END_TEST_FILES = [
     # L1
     # science
-    "L1/2021/06/28/SCI/solo_L1_stix-sci-xray-rpd_20210628T092301-20210628T092501_V01_2106280010-54759.fits", # noqa
-    "L1/2021/06/28/SCI/solo_L1_stix-sci-xray-cpd_20210628T231112-20210628T233143_V01_2106280103-60638.fits", # noqa
-    "L1/2021/06/28/SCI/solo_L1_stix-sci-xray-scpd_20210628T092301-20210628T092502_V01_2106280006-54720.fits", # noqa
-    "L1/2021/06/28/SCI/solo_L1_stix-sci-xray-vis_20210628T092301-20210628T092502_V01_2106280004-54716.fits", # noqa
-    "L1/2021/09/13/SCI/solo_L1_stix-sci-aspect-burst_20210913T055800-20210913T060010_V01_0.fits", # noqa
-    "L1/2021/06/28/SCI/solo_L1_stix-sci-xray-spec_20210628T230112-20210628T234143_V01_2106280041-54988.fits", # noqa
+    "L1/2021/06/28/SCI/solo_L1_stix-sci-xray-rpd_20210628T092300-20210628T092500_V01_2106280010-54759.fits", # noqa
+    "L1/2021/06/28/SCI/solo_L1_stix-sci-xray-cpd_20210628T231111-20210628T233142_V01_2106280103-60638.fits", # noqa
+    "L1/2021/06/28/SCI/solo_L1_stix-sci-xray-scpd_20210628T092300-20210628T092501_V01_2106280005-54719.fits", # noqa
+    "L1/2021/06/28/SCI/solo_L1_stix-sci-xray-vis_20210628T092300-20210628T092501_V01_2106280004-54716.fits", # noqa
+    "L1/2021/09/13/SCI/solo_L1_stix-sci-aspect-burst_20210913T055758-20210914T095357_V01_0.fits", # noqa
+    "L1/2021/06/28/SCI/solo_L1_stix-sci-xray-spec_20210628T230111-20210628T234142_V01_2106280041-54988.fits", # noqa
     # QL
     "L1/2021/06/28/QL/solo_L1_stix-ql-background_20210628_V01.fits",
     "L1/2021/06/28/QL/solo_L1_stix-ql-flareflag_20210628_V01.fits",
@@ -41,8 +43,8 @@ END_TO_END_TEST_FILES = [
     "L1/2021/06/28/QL/solo_L1_stix-ql-variance_20210628_V01.fits",
     "L1/2021/06/28/CAL/solo_L1_stix-cal-energy_20210628_V01.fits",
     # HK
-    "L1/2021/06/28/HK/solo_L1_stix-hk-maxi_20210628_V01.fits",
-    "L1/2021/09/20/HK/solo_L1_stix-hk-mini_20210920_V01.fits"]
+    "L1/2021/09/20/HK/solo_L1_stix-hk-mini_20210920_V01.fits",
+    "L1/2021/06/28/HK/solo_L1_stix-hk-maxi_20210628_V01.fits"]
 
 remote = ["http://pub099.cs.technik.fhnw.ch/data/fits_test/" + x for x in END_TO_END_TEST_FILES]
 # files = ["/home/shane/fits_test/" + x for x in files]
@@ -76,25 +78,38 @@ def rebuild_end2end(files, *, splits=3,
     newroot = [Et.Element('Response') for i in splitfiles]
     newresponse = [Et.SubElement(newroot[i], 'PktRawResponse') for i in splitfiles]
 
-    xmlfiles = []
+    xmlfiles = defaultdict(set)
 
     for f, u in files:
         l1_f = Path(f)
+        print(f"{l1_f}: {l1_f.exists()}")
         l1_p = Product(l1_f)
         rootdir = l1_f.parent.parent.parent.parent.parent.parent
 
         for l0_p in l1_p.find_parent_products(rootdir):
-            for lb_p in l0_p.find_parent_products(rootdir):
-                xmlfiles.extend(lb_p.parent)
+            if isinstance(l0_p, ScienceProduct):
+                for prow in l0_p.control:
+                    xmlfiles[str(prow['raw_file'][0].decode())].update(prow['packet'])
+            else:
+                parents = l0_p.find_parent_products(rootdir)
+                for row in l0_p.control:
+                    for p in parents:
+                        packet = p.control[p.control['packet'] == row["packet"]]
+                        for prow in packet:
+                            xmlfiles[prow['raw_file']].add(row["packet"])
 
-    for xmlfile in set(xmlfiles):
+    print(f"{xmlfiles.keys()} TM files detected")
+
+    for xmlfile, packet_ids in xmlfiles.items():
         rootxml = Et.parse(socdir / xmlfile).getroot()
         for packet in rootxml.iter('PktRawResponseElement'):
-            packetid += 1
-            rpa = Et.SubElement(newresponse[packetid % splits], "PktRawResponseElement")
-            rpa.set("packetID", str(packetid))
-            pa = Et.SubElement(rpa, "packet")
-            pa.text = list(packet)[0].text
+            orig_pid = int(packet.get("packetID"))
+            if orig_pid in packet_ids:
+                packetid += 1
+                rpa = Et.SubElement(newresponse[packetid % splits], "PktRawResponseElement")
+                rpa.set("packetID", str(packetid))
+                pa = Et.SubElement(rpa, "packet")
+                pa.text = list(packet)[0].text
 
     print(f"{packetid} packets recompiled")
 
@@ -136,16 +151,11 @@ def end2end_pipeline(indir, fitsdir):
 
 
 if __name__ == '__main__2':
-    rebuild_end2end(files, splits=3, socdir=Path("/data/stix/SOLSOC/from_edds/tm/"),
-                    outdir=Path("/data/stix/out/test/e2e"))
-
-
-if __name__ == '__main__':
     if len(sys.argv) > 2:
         zippath = Path(sys.argv[1])
         datapath = Path(sys.argv[2])
 
-        rebuild_end2end(files, splits=3, outdir=datapath,
+        rebuild_end2end(files, splits=1, outdir=datapath,
                         socdir=Path("/data/stix/SOLSOC/from_edds/tm/"))
 
         if zippath.parent.exists() and datapath.exists():


### PR DESCRIPTION
after the fix of https://github.com/i4Ds/STIXCore/pull/261 i was able to back trace to the real packets and minimice the end2end test input. so the test should be much faster and more easy to track down any differences.

will fore sure not pass the current end2end