### PR TITLE
add soop api response foll all instruments

### DIFF
--- a/stixcore/data/test/soop/LTP03_Jan2021-Jun2021_PostSOWG.353.all.json
+++ b/stixcore/data/test/soop/LTP03_Jan2021-Jun2021_PostSOWG.353.all.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4698ae23b8fc26b0a4c0e4c4ec8ff6ef528404998598a319aecd3ca5ac1f426d
+size 13709

--- a/stixcore/data/test/soop/LTP04_Jun2021-Sep2021.2575.all.json
+++ b/stixcore/data/test/soop/LTP04_Jun2021-Sep2021.2575.all.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4698ae23b8fc26b0a4c0e4c4ec8ff6ef528404998598a319aecd3ca5ac1f426d
+size 13709

--- a/stixcore/data/test/soop/LTP04_Jun2021-Sep2021.2584.all.json
+++ b/stixcore/data/test/soop/LTP04_Jun2021-Sep2021.2584.all.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4698ae23b8fc26b0a4c0e4c4ec8ff6ef528404998598a319aecd3ca5ac1f426d
+size 13709

--- a/stixcore/data/test/soop/LTP05_Sep2021-Dec2021.1670.all.json
+++ b/stixcore/data/test/soop/LTP05_Sep2021-Dec2021.1670.all.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4698ae23b8fc26b0a4c0e4c4ec8ff6ef528404998598a319aecd3ca5ac1f426d
+size 13709

--- a/stixcore/processing/pipeline_cli.py
+++ b/stixcore/processing/pipeline_cli.py
@@ -216,7 +216,7 @@ def main():
 
     if ProductLevel.LB.value >= args.start_level.value:
         if has_input_files:
-            tmfiles = [SOCPacketFile(f) in input_files]
+            tmfiles = [SOCPacketFile(f) for f in input_files]
         else:
             tmfiles = soc.get_files(tmtc=TMTC.All if FILTER is None else FILTER)
 


### PR DESCRIPTION
the end2end testing might use the API to get SOOP data but this is not desired. so i added the a dedicated (small) set LUT as part of the repo just for the testing. 