### PR TITLE
Fix energy channel dimension of the RPD not being sliced back to requested energy channels

### DIFF
--- a/stixcore/products/level0/scienceL0.py
+++ b/stixcore/products/level0/scienceL0.py
@@ -249,6 +249,9 @@ class RawPixelData(ScienceProduct):
             if new_sum != orig_sum:
                 raise ValueError('Subscribed counts sum does not match original sum')
 
+        # Slice counts to only include requested energy channels
+        counts = counts[..., eids]
+
         sub_index = np.searchsorted(data['start_time'], unique_times)
         data = data[sub_index]
         data['time'] = control["time_stamp"][0] \


### PR DESCRIPTION
Forgot to do this for RPD when doing the the other data types in #296