### PR TITLE
Handle cases where SPICE pointing information is not available

### DIFF
--- a/stixcore/ephemeris/manager.py
+++ b/stixcore/ephemeris/manager.py
@@ -300,9 +300,14 @@ class Spice(SpiceKernelLoader, metaclass=Singleton):
         et = spiceypy.scs2e(SOLAR_ORBITER_ID, str(date))
         sc = spiceypy.sce2c(SOLAR_ORBITER_ID, et)
 
-        cmat, _ = spiceypy.ckgp(SOLAR_ORBITER_STIX_ILS_FRAME_ID, sc, 1.0, 'SOLO_SUN_RTN')
-        vec = cmat @ np.eye(3)
-        roll, pitch, yaw = spiceypy.m2eul(vec, 1, 2, 3)
+        with spiceypy.no_found_check():
+            try:
+                cmat, _ = spiceypy.ckgp(SOLAR_ORBITER_STIX_ILS_FRAME_ID, sc, 1.0, 'SOLO_SUN_RTN')
+                vec = cmat @ np.eye(3)
+                roll, pitch, yaw = spiceypy.m2eul(vec, 1, 2, 3)
+            except Exception as e:
+                logger.error(e)
+                roll, pitch, yaw = np.full(3, np.nan)
 
         # HeliographicStonyhurst
         solo_sun_hg, _ = spiceypy.spkezr('SOLO', et, 'SUN_EARTH_CEQU', 'None', 'Sun')

--- a/stixcore/ephemeris/tests/test_position.py
+++ b/stixcore/ephemeris/tests/test_position.py
@@ -43,6 +43,13 @@ def test_aux(spice):
     assert np.allclose(heeq, heeq_ref)
 
 
+def test_aux_missing(spice):
+    d = spice.datetime_to_scet(datetime(2023, 10, 7, 12))
+    orient, dist, car, heeq = spice.get_auxiliary_positional_data(date=d)
+    orient_ref = np.full(3, np.nan) * u.deg
+    assert np.allclose(orient, orient_ref, equal_nan=True)
+
+
 def test_get_orientation(spice):
     # from idl sunspice
     # CSPICE_FURNSH, 'test_position_20201001_V01.mk'


### PR DESCRIPTION
Add try catch around rotation matrix calculation and if not available set roll, yaw and pitch to nans.