### PR TITLE
Fix bug when adding HK products which use full SCET time.

### DIFF
--- a/stixcore/products/product.py
+++ b/stixcore/products/product.py
@@ -525,7 +525,7 @@ class GenericProduct(BaseProduct):
 
         # Fits write we do np.around(time - start_time).as_float().to(u.cs)).astype("uint32"))
         # So need to do something similar here to avoid comparing un-rounded value to rounded values
-        data['time_float'] = np.around((data['time'].min() - data['time']).as_float().to('cs'))
+        data['time_float'] = np.around((data['time'] - data['time'].min()).as_float().to('cs'))
 
         # remove dublicate data based on time bin and sort the data
         data = unique(data, keys=['time_float'])

--- a/stixcore/products/product.py
+++ b/stixcore/products/product.py
@@ -523,8 +523,9 @@ class GenericProduct(BaseProduct):
 
         logger.debug('len stacked %d', len(data))
 
-        # Not sure where the rounding issue is arising need to investigate
-        data['time_float'] = np.around(data['time'].as_float().value, 2)
+        # Fits write we do np.around(time - start_time).as_float().to(u.cs)).astype("uint32"))
+        # So need to do something similar here to avoid comparing un-rounded value to rounded values
+        data['time_float'] = np.around((data['time'].min() - data['time']).as_float().to('cs'))
 
         # remove dublicate data based on time bin and sort the data
         data = unique(data, keys=['time_float'])


### PR DESCRIPTION
When adding two producst one of the time arrays comes from TM so has full SCET timestamp, the otehr comes from the fits file which has been converted to a relative time and rounded. Thus when compared they appear different and the merge keeps both. This commit rounds the time from TM in simlar manner to when written to fits.

Closes #357