### PR TITLE
Various small fixes for data release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,7 @@ jobs:
     envs:
       - macos: py39
         name: py39_mac
+        coverage: false
 
       - windows: py39
         name: py39_win

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ jobs:
     toxdeps: tox-pypi-filter
     submodules: true
     coverage: codecov
+    default_python: '3.9'
     envs:
       - macos: py39
         name: py39_mac

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,11 +66,15 @@ max-line-length = 100
 testpaths = "stixcore" "docs"
 doctest_plus = enabled
 text_file_format = rst
-addopts = --doctest-rst
+addopts =
+    --doctest-rst
+    --strict-markers
 remote_data_strict = False
 rsyncdirs = stixcore/data
 filterwarnings =
     ignore:Matplotlib is currently using agg:UserWarning
+markers =
+    end2end
 
 [isort]
 balanced_wrapping = True

--- a/stixcore/io/fits/processors.py
+++ b/stixcore/io/fits/processors.py
@@ -614,8 +614,8 @@ class FitsL0Processor:
             elow, ehigh, channel = product.get_energies()
             energies = QTable()
             energies['channel'] = np.uint8(channel)
-            energies['e_low'] = np.float16(elow)
-            energies['e_high'] = np.float16(ehigh)
+            energies['e_low'] = np.float32(elow)
+            energies['e_high'] = np.float32(ehigh)
 
             energy_enc = fits.connect._encode_mixins(energies)
             energy_hdu = table_to_hdu(energy_enc)

--- a/stixcore/io/fits/processors.py
+++ b/stixcore/io/fits/processors.py
@@ -601,7 +601,7 @@ class FitsL0Processor:
     @staticmethod
     def add_optional_energy_table(product, hdul):
         """
-        Generate and add a energy table extension if energy data is avaialable.
+        Generate and add an energy table extension if energy data is available.
 
         Parameters
         ----------
@@ -610,7 +610,8 @@ class FitsL0Processor:
         hdul : list
             list of all extensions the energy to add to
         """
-        if getattr(product, 'get_energies', False) is not False and not product.ssid == 42:
+        # 41, 42 are QL Cal and BSD Aspect and should not have energy HDUs
+        if getattr(product, 'get_energies', False) is not False and product.ssid not in {41, 42}:
             elow, ehigh, channel = product.get_energies()
             energies = QTable()
             energies['channel'] = np.uint8(channel)

--- a/stixcore/processing/tests/test_end2end.py
+++ b/stixcore/processing/tests/test_end2end.py
@@ -38,11 +38,13 @@ def orig_fits(orig_data):
     return list(orig_data.rglob("*.fits"))
 
 
+@pytest.mark.end2end
 @pytest.fixture(scope="session")
 def current_fits(orig_data, out_dir):
     return end2end_pipeline(orig_data, out_dir)
 
 
+@pytest.mark.end2end
 def test_find_parents(current_fits, out_dir):
     for fits in current_fits:
         p = Product(fits)

--- a/stixcore/products/level0/scienceL0.py
+++ b/stixcore/products/level0/scienceL0.py
@@ -348,7 +348,7 @@ class CompressedPixelData(ScienceProduct):
         data['triggers'] = triggers.T.astype(get_min_uint(triggers))
         data['triggers'].meta = {'NIXS': [f'NIX00{i}' for i in range(242, 258)]}
         data['triggers_comp_err'] = np.float32(np.sqrt(triggers_var).T)
-        data.add_basic(name='num_energy_groups', nix='NIX00258', packets=packets, dtype=np.ubyte)
+        # data.add_basic(name='num_energy_groups', nix='NIX00258', packets=packets, dtype=np.ubyte)
 
         tmp = dict()
         tmp['e_low'] = np.array(packets.get_value('NIXD0016'), np.ubyte)
@@ -499,7 +499,7 @@ class CompressedPixelData(ScienceProduct):
         data['control_index'] = control['index'][0]
 
         data = data['time', 'timedel', 'rcr', 'pixel_masks', 'detector_masks', 'num_pixel_sets',
-                    'num_energy_groups', 'triggers', 'triggers_comp_err',
+                    'triggers', 'triggers_comp_err',
                     'counts', 'counts_comp_err']
         data['control_index'] = np.ubyte(0)
 
@@ -566,13 +566,6 @@ class Visibility(ScienceProduct):
         data['control_index'] = np.full(len(data['delta_time']), 0)
         unique_times = np.unique(data['delta_time'])
 
-        # time = np.array([])
-        # for dt in set(self.delta_time):
-        #     i, = np.where(self.delta_time == dt)
-        #     nt = sum(np.array(packets['NIX00258'])[i])
-        #     time = np.append(time, np.repeat(dt, nt))
-        # self.time = time
-
         data.add_basic(name='rcr', nix='NIX00401', attr='value', packets=packets)
 
         data.add_data('pixel_mask1', _get_pixel_mask(packets, 'NIXD0407'))
@@ -600,8 +593,6 @@ class Visibility(ScienceProduct):
 
         tids = np.searchsorted(data['delta_time'], unique_times)
         data = data[tids]
-
-        # sum(packets.get_value('NIX00258'))
 
         # Data
         e_low = np.array(packets.get_value('NIXD0016'))

--- a/stixcore/products/tests/test_housekeeping.py
+++ b/stixcore/products/tests/test_housekeeping.py
@@ -26,13 +26,13 @@ testpackets = [(test_data.tmtc.TM_3_25_1, MiniReportL0, MiniReportL1, 'mini',
                 '0660258881:33104', '0660258881:33104', 1)]
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def soop_manager():
     SOOPManager.instance = SOOPManager(test_data.soop.DIR)
     return SOOPManager.instance
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def idbm():
     return IDBManager(test_data.idb.DIR)
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
 extras =
     test
 commands =
-    pytest --pyargs stixcore {toxinidir}/docs --cov stixcore --cov-config={toxinidir}/setup.cfg --remote-data=any -m "not end2end"  {posargs}
+    pytest --pyargs stixcore {toxinidir}/docs --cov stixcore --cov-config={toxinidir}/setup.cfg --remote-data=any -m "not end2end" -n 1 --dist no {posargs}
 
 
 [testenv:build_docs]

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ requires =
 pypi_filter_requirements = https://raw.githubusercontent.com/sunpy/package-template/master/sunpy_version_pins.txt
 
 # Pass through the following environemnt variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
+passenv = HOME, WINDIR, LC_ALL, LC_CTYPE, CC, CI, TRAVIS
 
 # Run the tests in a temporary directory to make sure that we don't import
 # the package from the source tree
@@ -42,7 +42,7 @@ deps =
 extras =
     test
 commands =
-    pytest --pyargs stixcore {toxinidir}/docs --cov stixcore --cov-config={toxinidir}/setup.cfg --remote-data=any -m "not end2end" -n 1 --dist loadfile {posargs}
+    pytest --pyargs stixcore {toxinidir}/docs --cov stixcore --cov-config={toxinidir}/setup.cfg --remote-data=any -m "not end2end"  {posargs}
 
 
 [testenv:build_docs]


### PR DESCRIPTION
Fixes:
1. Actually calculate the Carrington coordinate frame values and use in the headers, closes #355
2. Fix casting issue with fits ext for energy table, closes #359
3. Remove num_energy_groups, closes #367 
4. Remove energy extension from QL Calibration data, close #338 