### PR TITLE
Add support for trigger scaling in compression mode S=0,k=0,M=7

### DIFF
--- a/stixcore/processing/decompression.py
+++ b/stixcore/processing/decompression.py
@@ -51,8 +51,9 @@ def decompress(packet):
         return 0
     c = 0
     for param_name, (sn, kn, mn) in decompression_parameter.items():
-        skm = (sn if isinstance(sn, int) else packet.data.get(sn),  # option to configure exceptions
+        skm = (sn if isinstance(sn, int) else packet.data.get(sn),
                kn if isinstance(kn, int) else packet.data.get(kn),
                mn if isinstance(mn, int) else packet.data.get(mn))
+
         c += packet.data.apply(param_name, apply_decompress,  skm)
     return c

--- a/stixcore/products/common.py
+++ b/stixcore/products/common.py
@@ -321,20 +321,18 @@ def unscale_triggers(scaled_triggers, *, integration, detector_masks, ssid, fact
     active_trigger_groups = active_detectors_per_trigger_group >= 1
 
     # QL are summed to total trigger (1 trigger value)
-    if ssid in {30, 31, 32}:
+    # BSD SPEC data are summed to total trigger (1 trigger value)
+    if ssid in {30, 31, 32, 24}:
         n_group = active_trigger_groups.astype(int).sum()
+        n_int = integration.as_float().to_value(u.ds).reshape(-1, 1)  # units of 0.1s
     # BSD pixel/vis data not summed (16 trigger values)
     elif ssid in {21, 22, 23}:
         n_group = active_trigger_groups.astype(int)
-    # BSD SPEC data are summed to total trigger (1 trigger value)
-    elif ssid == 24:
-        n_group = active_trigger_groups.astype(int).sum()
+        n_int = integration.as_float().to_value(u.ds)  # units of 0.1s
     else:
         raise ValueError(f'Unscaling not support for SSID {ssid}')
 
-    n_int = integration.as_float().to_value(u.ds)  # units of 0.1s
-
-    # Scaled to ints onboard, so bins have scaled width of 1, so error is 0.5 times the total factor
+    # Scaled to ints onboard, bins have scaled width of 1, so error is 0.5 times the total factor
     scaling_error = np.full_like(scaled_triggers, 0.5, dtype=float) * n_group.T * n_int * factor
     # The FSW essential floors the value so add 0.5 so trigger is the centre of range +/- error
     unscaled_triggers = (scaled_triggers * n_group.T * n_int * factor) + scaling_error

--- a/stixcore/products/common.py
+++ b/stixcore/products/common.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 import numpy as np
 
+import astropy.units as u
+
 from stixcore.config.reader import get_sci_channels, read_energy_channels
 from stixcore.util.logging import get_logger
 
@@ -278,3 +280,63 @@ def rebin_proportional(y1, x1, x2):
     y2 += np.where(different_cell, contrib, 0.)
 
     return y2
+
+
+def unscale_triggers(scaled_triggers, *, integration, detector_masks, ssid, factor=30):
+    r"""
+    Unscale scaled trigger values.
+
+    Trigger values are scaled on board in compression mode 0,0,7 via the following relation
+
+    T_s = T / (factor * n_int * n_trig_groups)
+
+    where `factor` is a configured parameter, `n_int` is the duration in units of 0.1s and
+    `n_trig_groups` number of active trigger groups being summed, which depends on the data
+    product given by the SSID.
+
+    Parameters
+    ----------
+    scaled_triggers : int
+        Scaled trigger
+    integration : `astropy.units.Quantity`
+        Number of integrations (integration time / 0.1s)
+    detector_masks : `array-like`
+        Number of trigger groups summed
+    ssid : `int`
+        Science Structure ID
+    factor : int optional
+        Scaling factor
+    Returns
+    -------
+    tuple
+        Unscaled triggers, Scaling Variance
+    """
+    # TODO extract this to a separate function and test
+    detector_to_trigger_group_map = np.array(
+        [[1,  6,  5, 12, 14, 10,  8,  3, 31, 26, 22, 20, 18, 17, 24, 29],
+         [2,  7, 11, 13, 15, 16,  9,  4, 32, 27, 28, 21, 19, 23, 25, 30]]).T
+
+    trigger_groups = detector_masks[:, [np.array(detector_to_trigger_group_map) - 1]]
+    active_detectors_per_trigger_group = trigger_groups.squeeze().sum(axis=-1)
+    active_trigger_groups = active_detectors_per_trigger_group >= 1
+
+    # QL are summed to total trigger (1 trigger value)
+    if ssid in {30, 31, 32}:
+        n_group = active_trigger_groups.astype(int).sum()
+    # BSD pixel/vis data not summed (16 trigger values)
+    elif ssid in {21, 22, 23}:
+        n_group = active_trigger_groups.astype(int)
+    # BSD SPEC data are summed to total trigger (1 trigger value)
+    elif ssid == 24:
+        n_group = active_trigger_groups.astype(int).sum()
+    else:
+        raise ValueError(f'Unscaling not support for SSID {ssid}')
+
+    n_int = integration.as_float().to_value(u.ds)  # units of 0.1s
+
+    # Scaled to ints onboard, so bins have scaled width of 1, so error is 0.5 times the total factor
+    scaling_error = np.full_like(scaled_triggers, 0.5, dtype=float) * n_group.T * n_int * factor
+    # The FSW essential floors the value so add 0.5 so trigger is the centre of range +/- error
+    unscaled_triggers = (scaled_triggers * n_group.T * n_int * factor) + scaling_error
+
+    return unscaled_triggers, scaling_error**2

--- a/stixcore/products/level0/quicklookL0.py
+++ b/stixcore/products/level0/quicklookL0.py
@@ -243,10 +243,14 @@ class Background(QLProduct):
 
         triggers = packets.get_value('NIX00274').T
         triggers_var = packets.get_value('NIX00274', attr="error").T
+
+        # As fixed not sent in TM so hard code here BKC detector is index 9
+        dmask = np.zeros(shape=(1, 32), dtype=int)
+        dmask[0, 9] = 1
         if control['compression_scheme_triggers_skm'].tolist() == [[0, 0, 7]]:
             logger.debug('Unscaling trigger ')
             triggers, triggers_var = unscale_triggers(
-                triggers, integration=duration, detector_masks=control['detector_mask'],
+                triggers, integration=duration, detector_masks=dmask,
                 ssid=levelb.ssid)
 
         data = Data()
@@ -330,17 +334,21 @@ class Spectra(QLProduct):
         counts_var = np.vstack(counts_var).T
         counts = np.pad(counts, ((pad_before, pad_after), (0, 0)), constant_values=0)
         counts_var = np.pad(counts_var, ((pad_before, pad_after), (0, 0)), constant_values=0)
-        triggers = packets.get_value('NIX00484').T.reshape(-1)
-        triggers_var = packets.get_value('NIX00484', attr='error').T.reshape(-1)
+        triggers = packets.get_value('NIX00484').T
+        triggers_var = packets.get_value('NIX00484', attr='error').T
 
-        if control['compression_scheme_triggers_skm'].tolist == [[0, 0, 7]]:
+        # These are per detector spectra so n_acc is 1 by design and not in TM so hard code here
+        dmask = np.zeros(shape=(1, 32), dtype=int)
+        dmask[0, 9] = 1
+
+        if control['compression_scheme_triggers_skm'].tolist() == [[0, 0, 7]]:
             logger.debug('Unscaling trigger ')
             triggers, triggers_var = unscale_triggers(
-                triggers, integration=duration, detector_masks=control['detector_mask'],
+                triggers, integration=duration, detector_masks=dmask,
                 ssid=levelb.ssid)
 
-        triggers = np.pad(triggers, (pad_before, pad_after), mode='edge')
-        triggers_var = np.pad(triggers_var, (pad_before, pad_after), mode='edge')
+        triggers = np.pad(triggers, ((pad_before, pad_after), (0, 0)), mode='edge')
+        triggers_var = np.pad(triggers_var, ((pad_before, pad_after), (0, 0)), mode='edge')
 
         detector_index = np.pad(np.array(did, np.int16), (pad_before, pad_after), mode='edge')
         num_integrations = np.pad(np.array(packets.get_value('NIX00485'), np.uint16),

--- a/stixcore/products/level0/quicklookL0.py
+++ b/stixcore/products/level0/quicklookL0.py
@@ -16,6 +16,7 @@ from stixcore.products.common import (
     _get_sub_spectrum_mask,
     get_min_uint,
     rebin_proportional,
+    unscale_triggers,
 )
 from stixcore.products.product import Control, Data, EnergyChannelsMixin, GenericProduct
 from stixcore.time import SCETime, SCETimeDelta, SCETimeRange
@@ -151,6 +152,11 @@ class LightCurve(QLProduct):
 
         triggers = packets.get_value('NIX00274').T
         triggers_var = packets.get_value('NIX00274', attr="error").T
+        if control['compression_scheme_triggers_skm'].tolist() == [[0, 0, 7]]:
+            logger.debug('Unscaling trigger ')
+            triggers, triggers_var = unscale_triggers(
+                triggers, integration=duration,
+                detector_masks=control['detector_mask'], ssid=levelb.ssid)
 
         data = Data()
         data['control_index'] = control_indices
@@ -237,6 +243,11 @@ class Background(QLProduct):
 
         triggers = packets.get_value('NIX00274').T
         triggers_var = packets.get_value('NIX00274', attr="error").T
+        if control['compression_scheme_triggers_skm'].tolist() == [[0, 0, 7]]:
+            logger.debug('Unscaling trigger ')
+            triggers, triggers_var = unscale_triggers(
+                triggers, integration=duration, detector_masks=control['detector_mask'],
+                ssid=levelb.ssid)
 
         data = Data()
         data['control_index'] = control_indices
@@ -321,6 +332,13 @@ class Spectra(QLProduct):
         counts_var = np.pad(counts_var, ((pad_before, pad_after), (0, 0)), constant_values=0)
         triggers = packets.get_value('NIX00484').T.reshape(-1)
         triggers_var = packets.get_value('NIX00484', attr='error').T.reshape(-1)
+
+        if control['compression_scheme_triggers_skm'].tolist == [[0, 0, 7]]:
+            logger.debug('Unscaling trigger ')
+            triggers, triggers_var = unscale_triggers(
+                triggers, integration=duration, detector_masks=control['detector_mask'],
+                ssid=levelb.ssid)
+
         triggers = np.pad(triggers, (pad_before, pad_after), mode='edge')
         triggers_var = np.pad(triggers_var, (pad_before, pad_after), mode='edge')
 

--- a/stixcore/products/product.py
+++ b/stixcore/products/product.py
@@ -92,6 +92,27 @@ def read_qtable(file, hdu, hdul=None):
 
 class AddParametersMixin:
     def add_basic(self, *, name, nix, packets, attr=None, dtype=None, reshape=False):
+        r"""
+        Add parameter taken directly from the packets.
+        Parameters
+        ----------
+        name : `str`
+            Name of the column for the data
+        nix : `str`
+            Parameters id
+        packets : `
+        attr : `str`
+            The attribute e.g `raw`, or `error`
+        dtype :
+            The type to store the data as
+        reshape: `bool`
+            Reshape to a `1, X` array
+
+
+        Returns
+        -------
+        None
+        """
         value = packets.get_value(nix, attr=attr)
         if reshape is True:
             value = value.reshape(1, -1)
@@ -99,11 +120,44 @@ class AddParametersMixin:
         self.add_meta(name=name, nix=nix, packets=packets, add_curtx=(attr == "value"))
 
     def add_data(self, name, data_meta):
+        r"""
+        Add the given data and metadata to table.
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the column for the data
+        data_meta : `tuple`
+            Data, meta data pair
+
+        Returns
+        -------
+        None
+
+        """
         data, meta = data_meta
         self[name] = data
         self[name].meta = meta
 
     def add_meta(self, *, name, nix, packets, add_curtx=False):
+        r"""
+        Add metadata extracted from packets.
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the column for the data
+        nix : `str`
+            Parameters ID e.g. 'NIX00404'
+        packets :
+            The packets
+        add_curtx
+
+
+        Returns
+        -------
+
+        """
         param = packets.get(nix)
         idb_info = param[0].idb_info
         meta = {'NIXS': nix}

--- a/stixcore/products/tests/test_scaling.py
+++ b/stixcore/products/tests/test_scaling.py
@@ -21,9 +21,9 @@ def test_unscale(factor, n_int, ssid):
 
     norm = n_groups * n_int * factor
 
-    triggers_in = np.tile(np.arange(255*n_int*factor).reshape(-1, 1), 16, )
+    triggers_in = np.repeat(np.arange(255*n_int*factor).reshape(-1, 1), 16, axis=1)
     if ssid == 24:
-        triggers_in = triggers_in.sum(axis=1)
+        triggers_in = triggers_in.sum(axis=1, keepdims=True)
 
     triggers_scaled = np.floor(triggers_in / norm)
     trigger_unscaled_var = 0.5 * norm

--- a/stixcore/products/tests/test_scaling.py
+++ b/stixcore/products/tests/test_scaling.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+import astropy.units as u
+
+from stixcore.products.common import unscale_triggers
+from stixcore.time import SCETimeDelta
+
+
+@pytest.mark.parametrize('factor', [20, 30, 40])
+@pytest.mark.parametrize('n_int', [10, 20, 30])
+@pytest.mark.parametrize('ssid', [21, 22, 23, 24])
+def test_unscale(factor, n_int, ssid):
+    dmask = np.ones((1, 32))
+    duration = SCETimeDelta(n_int * u.ds)
+
+    n_groups = 1
+    if ssid == 24:
+        n_groups = 16
+
+    norm = n_groups * n_int * factor
+
+    triggers_in = np.tile(np.arange(255*n_int*factor).reshape(-1, 1), 16, )
+    if ssid == 24:
+        triggers_in = triggers_in.sum(axis=1)
+
+    triggers_scaled = np.floor(triggers_in / norm)
+    trigger_unscaled_var = 0.5 * norm
+    triggers_unscaled = triggers_scaled * norm + trigger_unscaled_var
+    triggers_out, trigger_out_var = unscale_triggers(triggers_scaled, integration=duration,
+                                                     detector_masks=dmask, ssid=ssid, factor=factor)
+    assert_array_equal(triggers_out, triggers_unscaled)
+    assert_array_equal(trigger_out_var, trigger_unscaled_var**2)


### PR DESCRIPTION
Unscale trigger data when compressed with mode S=0,k=0,M=7

 * QL - LC, BKG, SPECTRA
 * BSD -  CPD, SCPD, VIS and SPEC

When compressed with mode 0,0,7 the trigger are scaled by the FSW according to `T_s = T / (n_int * n_acc * factor)` this scaling is removed by the GSW.

Closes #365 