### PR TITLE
Fix bug in spectrogram time bin calculations

### DIFF
--- a/stixcore/products/level1/scienceL1.py
+++ b/stixcore/products/level1/scienceL1.py
@@ -104,6 +104,7 @@ class Spectrogram(ScienceProduct, L1Mixin):
 
     In level 1 format.
     """
+    PRODUCT_PROCESSING_VERSION = 4
 
     def __init__(self, *, service_type, service_subtype, ssid, control,
                  data, idb_versions=defaultdict(SCETimeRange), **kwargs):


### PR DESCRIPTION
* Only use the closing time offset (NIX00269) for the last science substructure to calculate the time bins.