### PR TITLE
Don't raise an error on QL spectra reshape emit warning instead

### DIFF
--- a/stixcore/processing/L0toL1.py
+++ b/stixcore/processing/L0toL1.py
@@ -10,6 +10,7 @@ from stixcore.config.config import CONFIG
 from stixcore.ephemeris.manager import Spice, SpiceKernelManager
 from stixcore.io.fits.processors import FitsL1Processor
 from stixcore.products import Product
+from stixcore.products.level0.quicklookL0 import QLSpectraReshapeError
 from stixcore.products.level0.scienceL0 import NotCombineException
 from stixcore.soop.manager import SOOPManager
 from stixcore.util.logging import get_logger
@@ -112,6 +113,10 @@ def process_type(files, *, processor, soopmanager, spice_kernel_path, config):
             logger.warning("No match for product %s", l0)
         except NotCombineException as nc:
             logger.info(nc)
+        except QLSpectraReshapeError as e:
+            logger.info(str(e))
+            if CONFIG.getboolean("Logging", "stop_on_error", fallback=False):
+                raise e
         except Exception as e:
             logger.error("Error processing file %s", file, exc_info=True)
             logger.error("%s", e)

--- a/stixcore/products/level0/quicklookL0.py
+++ b/stixcore/products/level0/quicklookL0.py
@@ -1,7 +1,7 @@
 """
 High level STIX data products created from single stand alone packets or a sequence of packets.
 """
-
+import warnings
 from itertools import chain, repeat
 from collections import defaultdict
 
@@ -374,9 +374,18 @@ class Spectra(QLProduct):
         did = packets.get_value("NIX00100")
         pad_before = did[0]
         pad_after = 31 - did[-1]
-        control_indices = np.hstack([np.full(ns, cind) for ns, cind in control[["num_samples", "index"]]])
-        control_indices = np.pad(control_indices, (pad_before, pad_after), mode="edge")
-        control_indices = control_indices.reshape(-1, 32)
+        control_indices = np.hstack([np.full(ns, cind) for ns, cind
+                                     in control[['num_samples', 'index']]])
+        control_indices = np.pad(control_indices, (pad_before, pad_after),
+                                 mode='edge')
+        try:
+            control_indices = control_indices.reshape(-1, 32)
+        except ValueError as e:
+            err_message = str(e)
+            if 'cannot reshape array' in err_message:
+                warnings.warn(err_message)
+            else:
+                raise e
 
         duration, time, scet_timerange = cls._get_time(control, num_energies, packets, pad_before, pad_after)
 


### PR DESCRIPTION
At the moment we get these error every day and may be missing real errors as in the end the QL spectra a created properly. 

This PR attempts to disable the error to see will help until we can reproduce and fix the error (#421).
